### PR TITLE
added missing property tax ParamMetadata

### DIFF
--- a/bloodloan/ui/parameters.py
+++ b/bloodloan/ui/parameters.py
@@ -105,6 +105,10 @@ class Params:
                 ipywidgets.BoundedFloatText,
                 {'min': -20.0, 'max': 20.0, 'step': 0.5, 'value': 0.5}),
             ParamMetadata(
+                ParameterIds.PROPERTY_TAXES, "Monthly Property Tax",
+                ipywidgets.BoundedFloatText,
+                {'min': 75, 'max': 2_000, 'step': 25, 'value': 500}),              
+            ParamMetadata(
                 ParameterIds.ADDRESS, "Property address",
                 ipywidgets.Textarea, {'value': ""}),
             ParamMetadata(


### PR DESCRIPTION
Params class has the list widgetsmd. It is missing a ParamMetaData() value for ParametsrIds.PROPERTY_TAXES

Adding this value fixes a key error for missing params.property_taxes when running ui.main() cell in the notebook